### PR TITLE
Explicitly set minimum supported rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "argon2-kdf"
 version = "1.5.4"
+rust-version = "1.82.0"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"


### PR DESCRIPTION
# Motivation

I tried compiling your crate with `rustc 1.81.0` and got an unexpected `error: extern block cannot be declared unsafe`

![2025-01-13_09-12](https://github.com/user-attachments/assets/69f4d533-4b92-4fa3-882a-01d6db9d89ef)

The fix was (of cause) to update my rust version as the feature `unsafe_extern_blocks` wasn't stable at `1.81.0`.
But of cause that error is kind of unreadable if you don't already know why it is happening.

(The feature was stabilized with [`rustc 1.82`](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#safe-items-with-unsafe-extern))

# Improvements

It would be nice to *explicitly* set the [`rust-version`](https://doc.rust-lang.org/stable/cargo/reference/rust-version.html) that this crate support, so that the error is `error: rustc 1.84.0 is not supported by the following packages:` instead.

![2025-01-13_09-23](https://github.com/user-attachments/assets/62452e4c-a175-4185-a84e-93a511b8fb3e)

That would also have other benefits as triggering `cargo clippy`s [`incompatible_msrv`](https://rust-lang.github.io/rust-clippy/stable/index.html#incompatible_msrv) to make it obvious when accidentally breaking the minimum required rust version (msrv).
(Which is considered a minor version bump by rust in terms of semver)
